### PR TITLE
Fix lowercase issues in Vectorizers for special characters

### DIFF
--- a/sklearn/feature_extraction/tests/cv_test.py
+++ b/sklearn/feature_extraction/tests/cv_test.py
@@ -1,0 +1,85 @@
+from mmap import ALLOCATIONGRANULARITY
+from unittest import expectedFailure
+import pytest 
+from sklearn.feature_extraction.text import CountVectorizer, HashingVectorizer
+
+
+def test_1():
+    x = ['This is Problematic™.','THIS IS NOT']
+
+    cv = CountVectorizer(
+        lowercase=True,
+        strip_accents='unicode',
+        ngram_range=(1,1),
+        lowercase_after_accent_functions=False
+    )
+
+    x_v = cv.fit_transform(x)
+
+    actual = cv.get_feature_names_out()
+    expected = ['is', 'not', 'problematicTM', 'this']
+    
+    assert len(actual) == len(expected)
+    assert all([a == b for a, b in zip(actual, expected)])
+
+def test_2():
+    x = ['This is Problematic™.','THIS IS NOT']
+
+    cv = CountVectorizer(
+        lowercase=True,
+        strip_accents='unicode',
+        ngram_range=(1,1),
+        lowercase_after_accent_functions=True
+    )
+
+    x_v = cv.fit_transform(x)
+
+    actual = cv.get_feature_names_out()
+    expected = ['is', 'not', 'problematictm', 'this']
+    
+    assert len(actual) == len(expected)
+    assert all([a == b for a, b in zip(actual, expected)])
+
+def test_3():
+    x = ['This is ProblematicTM.','THIS IS NOT']
+
+    cv = CountVectorizer(
+        lowercase=True,
+        strip_accents='unicode',
+        ngram_range=(1,1),
+        lowercase_after_accent_functions=True
+    )
+
+    x_v = cv.fit_transform(x)
+
+    actual = cv.get_feature_names_out()
+    expected = ['is', 'not', 'problematictm', 'this']
+    
+    assert len(actual) == len(expected)
+    assert all([a == b for a, b in zip(actual, expected)])
+
+def test_4():
+    x = ['This is ProblematicTM.','THIS IS NOT']
+
+    cv = CountVectorizer(
+        lowercase=True,
+        strip_accents='unicode',
+        ngram_range=(1,1),
+        lowercase_after_accent_functions=False
+    )
+
+    x_v = cv.fit_transform(x)
+
+    actual = cv.get_feature_names_out()
+    expected = ['is', 'not', 'problematictm', 'this']
+    
+    assert len(actual) == len(expected)
+    assert all([a == b for a, b in zip(actual, expected)])
+
+    
+
+
+
+
+if __name__ == '__main__':
+    pytest.main()

--- a/sklearn/feature_extraction/tests/cv_test.py
+++ b/sklearn/feature_extraction/tests/cv_test.py
@@ -4,7 +4,7 @@ import pytest
 from sklearn.feature_extraction.text import CountVectorizer, HashingVectorizer
 
 
-def test_1():
+def test_laacFalse_withTrademark():
     x = ['This is Problematic™.','THIS IS NOT']
 
     cv = CountVectorizer(
@@ -22,7 +22,7 @@ def test_1():
     assert len(actual) == len(expected)
     assert all([a == b for a, b in zip(actual, expected)])
 
-def test_2():
+def test_laacTrue_withTrademark():
     x = ['This is Problematic™.','THIS IS NOT']
 
     cv = CountVectorizer(
@@ -40,7 +40,7 @@ def test_2():
     assert len(actual) == len(expected)
     assert all([a == b for a, b in zip(actual, expected)])
 
-def test_3():
+def test_laacTrue_withoutTrademark():
     x = ['This is ProblematicTM.','THIS IS NOT']
 
     cv = CountVectorizer(
@@ -58,7 +58,7 @@ def test_3():
     assert len(actual) == len(expected)
     assert all([a == b for a, b in zip(actual, expected)])
 
-def test_4():
+def test_laacFalse_withoutTrademark():
     x = ['This is ProblematicTM.','THIS IS NOT']
 
     cv = CountVectorizer(

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -47,7 +47,7 @@ __all__ = [
 ]
 
 
-def _preprocess(doc, accent_function=None, lower=False):
+def _preprocess(doc, accent_function=None, lower=False, lowercase_after_accent_functions=False):
     """Chain together an optional series of text preprocessing steps to
     apply to a document.
 
@@ -70,6 +70,8 @@ def _preprocess(doc, accent_function=None, lower=False):
         doc = doc.lower()
     if accent_function is not None:
         doc = accent_function(doc)
+    if lowercase_after_accent_functions:
+        doc = doc.lower()
     return doc
 
 
@@ -334,7 +336,7 @@ class _VectorizerMixin:
                 'Invalid value for "strip_accents": %s' % self.strip_accents
             )
 
-        return partial(_preprocess, accent_function=strip_accents, lower=self.lowercase)
+        return partial(_preprocess, accent_function=strip_accents, lower=self.lowercase, lowercase_after_accent_functions=self.lowercase_after_accent_functions)
 
     def build_tokenizer(self):
         """Return a function that splits a string into a sequence of tokens.
@@ -629,6 +631,13 @@ class HashingVectorizer(TransformerMixin, _VectorizerMixin, BaseEstimator):
     lowercase : bool, default=True
         Convert all characters to lowercase before tokenizing.
 
+    lowercase_after_accent_functions : bool, default=True
+        Convert all characters to lowercase after calling the accent_functions
+        and before tokenizing. This could avoid issues when special characters
+        present in the input, for example, the trademark symbol TM. If it
+        is False, the trademark symbol will be in uppercase TM in this case.
+        Otherwise, it will be in lowercase tm.
+
     preprocessor : callable, default=None
         Override the preprocessing (string transformation) stage while
         preserving the tokenizing and n-grams generation steps.
@@ -732,6 +741,7 @@ class HashingVectorizer(TransformerMixin, _VectorizerMixin, BaseEstimator):
         decode_error="strict",
         strip_accents=None,
         lowercase=True,
+        lowercase_after_accent_functions=True,
         preprocessor=None,
         tokenizer=None,
         stop_words=None,
@@ -752,6 +762,7 @@ class HashingVectorizer(TransformerMixin, _VectorizerMixin, BaseEstimator):
         self.tokenizer = tokenizer
         self.analyzer = analyzer
         self.lowercase = lowercase
+        self.lowercase_after_accent_functions = lowercase_after_accent_functions
         self.token_pattern = token_pattern
         self.stop_words = stop_words
         self.n_features = n_features
@@ -929,6 +940,13 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
     lowercase : bool, default=True
         Convert all characters to lowercase before tokenizing.
 
+    lowercase_after_accent_functions : bool, default=True
+        Convert all characters to lowercase after calling the accent_functions
+        and before tokenizing. This could avoid issues when special characters
+        present in the input, for example, the trademark symbol TM. If it
+        is False, the trademark symbol will be in uppercase TM in this case.
+        Otherwise, it will be in lowercase tm.
+
     preprocessor : callable, default=None
         Override the preprocessing (strip_accents and lowercase) stage while
         preserving the tokenizing and n-grams generation steps.
@@ -1094,6 +1112,7 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
         decode_error="strict",
         strip_accents=None,
         lowercase=True,
+        lowercase_after_accent_functions=True,
         preprocessor=None,
         tokenizer=None,
         stop_words=None,
@@ -1115,6 +1134,7 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
         self.tokenizer = tokenizer
         self.analyzer = analyzer
         self.lowercase = lowercase
+        self.lowercase_after_accent_functions = lowercase_after_accent_functions
         self.token_pattern = token_pattern
         self.stop_words = stop_words
         self.max_df = max_df
@@ -1749,6 +1769,13 @@ class TfidfVectorizer(CountVectorizer):
     lowercase : bool, default=True
         Convert all characters to lowercase before tokenizing.
 
+    lowercase_after_accent_functions : bool, default=True
+        Convert all characters to lowercase after calling the accent_functions
+        and before tokenizing. This could avoid issues when special characters
+        present in the input, for example, the trademark symbol TM. If it
+        is False, the trademark symbol will be in uppercase TM in this case.
+        Otherwise, it will be in lowercase tm.
+
     preprocessor : callable, default=None
         Override the preprocessing (string transformation) stage while
         preserving the tokenizing and n-grams generation steps.
@@ -1921,6 +1948,7 @@ class TfidfVectorizer(CountVectorizer):
         decode_error="strict",
         strip_accents=None,
         lowercase=True,
+        lowercase_after_accent_functions=True,
         preprocessor=None,
         tokenizer=None,
         analyzer="word",
@@ -1945,6 +1973,7 @@ class TfidfVectorizer(CountVectorizer):
             decode_error=decode_error,
             strip_accents=strip_accents,
             lowercase=lowercase,
+            lowercase_after_accent_functions=lowercase_after_accent_functions,
             preprocessor=preprocessor,
             tokenizer=tokenizer,
             analyzer=analyzer,


### PR DESCRIPTION
Fixed lowercase issues for special characters in Vectorizers by introducing a new parameter `lowercase_after_accent_functions`. By default it is True because we want to align it with the default `lowercase=True` behaviour. When it is True, it will lower the doc after calling the accent function.

Also added docs for `lowercase_after_accent_functions` and mentioned the special character issues.
```
    lowercase_after_accent_functions : bool, default=True
        Convert all characters to lowercase after calling the accent_functions
        and before tokenizing. This could avoid issues when special characters
        present in the input, for example, the trademark symbol TM. If it
        is False, the trademark symbol will be in uppercase TM in this case.
        Otherwise, it will be in lowercase tm.
```

Related issue: https://github.com/scikit-learn/scikit-learn/issues/21207