### PR TITLE
Allow extra weights in class_weight

### DIFF
--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -58,11 +58,15 @@ def compute_class_weight(class_weight, *, classes, y):
             raise ValueError(
                 "class_weight must be dict, 'balanced', or None, got: %r" % class_weight
             )
+        unweighted = []
         for i, c in enumerate(classes):
             if c in class_weight:
                 weight[i] = class_weight[c]
             else:
-                raise ValueError("Class label {} not present.".format(c))
+                unweighted.append(c)
+
+        if unweighted and (len(classes) - len(unweighted)) != len(class_weight):
+            raise ValueError("Class labels {} not present.".format(", ".join(map(str, unweighted))))
 
     return weight
 

--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -58,12 +58,11 @@ def compute_class_weight(class_weight, *, classes, y):
             raise ValueError(
                 "class_weight must be dict, 'balanced', or None, got: %r" % class_weight
             )
-        for c in class_weight:
-            i = np.searchsorted(classes, c)
-            if i >= len(classes) or classes[i] != c:
-                raise ValueError("Class label {} not present.".format(c))
-            else:
+        for i, c in enumerate(classes):
+            if c in class_weight:
                 weight[i] = class_weight[c]
+            else:
+                raise ValueError("Class label {} not present.".format(c))
 
     return weight
 

--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -3,12 +3,12 @@ import pytest
 
 from sklearn.datasets import make_blobs
 from sklearn.linear_model import LogisticRegression
+from sklearn.ensemble import RandomForestClassifier
 
 from sklearn.utils.class_weight import compute_class_weight
 from sklearn.utils.class_weight import compute_sample_weight
 from sklearn.utils._testing import assert_array_almost_equal
 from sklearn.utils._testing import assert_almost_equal
-
 
 def test_compute_class_weight():
     # Test (and demo) compute_class_weight.
@@ -38,7 +38,6 @@ def test_compute_class_weight_not_present():
         compute_class_weight("balanced", classes=classes, y=y)
     with pytest.raises(ValueError):
         compute_class_weight({0: 1.0, 1: 2.0}, classes=classes, y=y)
-
 
 def test_compute_class_weight_dict():
     classes = np.arange(3)
@@ -261,3 +260,9 @@ def test_compute_sample_weight_more_than_32():
     indices = np.arange(50)  # use subsampling
     weight = compute_sample_weight("balanced", y, indices=indices)
     assert_array_almost_equal(weight, np.ones(y.shape[0]))
+
+def test_extra_class_weight_labels():
+    # No error if extraneous class lebels are present
+    rfc = RandomForestClassifier(class_weight={1:10, 0:1})
+    rfc.fit([[0, 0, 1], [1, 0, 1]], [0, 0])
+

--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -51,17 +51,16 @@ def test_compute_class_weight_dict():
     # return them.
     assert_array_almost_equal(np.asarray([1.0, 2.0, 3.0]), cw)
 
-    # When a class weight is specified that isn't in classes, a ValueError
-    # should get raised
-    msg = "Class label 4 not present."
-    class_weights = {0: 1.0, 1: 2.0, 2: 3.0, 4: 1.5}
-    with pytest.raises(ValueError, match=msg):
-        compute_class_weight(class_weights, classes=classes, y=y)
 
-    msg = "Class label -1 not present."
+    # When a class weight is specified that isn't in classes, those class weights
+    # should be ignored
+    class_weights = {0: 1.0, 1: 2.0, 2: 3.0, 4: 1.5}
+    cw = compute_class_weight(class_weights, classes=classes, y=y)
+    assert_array_almost_equal([1.0, 2.0, 3.0], cw)
+
     class_weights = {-1: 5.0, 0: 1.0, 1: 2.0, 2: 3.0}
-    with pytest.raises(ValueError, match=msg):
-        compute_class_weight(class_weights, classes=classes, y=y)
+    cw = compute_class_weight(class_weights, classes=classes, y=y)
+    assert_array_almost_equal([1.0, 2.0, 3.0], cw)
 
 
 def test_compute_class_weight_invariance():
@@ -262,9 +261,4 @@ def test_compute_sample_weight_more_than_32():
     indices = np.arange(50)  # use subsampling
     weight = compute_sample_weight("balanced", y, indices=indices)
     assert_array_almost_equal(weight, np.ones(y.shape[0]))
-
-def test_extra_class_weight_labels():
-    # No error if extraneous class lebels are present
-    rfc = RandomForestClassifier(class_weight={1:10, 0:1})
-    rfc.fit([[0, 0, 1], [1, 0, 1]], [0, 0])
 

--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -62,6 +62,18 @@ def test_compute_class_weight_dict():
     cw = compute_class_weight(class_weights, classes=classes, y=y)
     assert_array_almost_equal([1.0, 2.0, 3.0], cw)
 
+def test_extra_class_weight_dict():
+    
+    # When a class weight is specified that isn't in classes, those class weights
+    # should be ignored
+    rfc = RandomForestClassifier(class_weight={1:10, 0:1})
+    rfc.fit([[0, 0, 1], [1, 0, 1]], [0, 0])
+    assert_array_almost_equal(rfc.predict([[1,0,1]]), [0])
+
+    rfc = RandomForestClassifier(class_weight={1:10, 0:1})
+    with pytest.raises(ValueError):
+        rfc.fit([[0, 0, 1], [1, 0, 1]], [0, 2])
+
 
 def test_compute_class_weight_invariance():
     # Test that results with class_weight="balanced" is invariant wrt

--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -28,16 +28,18 @@ def test_compute_class_weight_not_present():
     y = np.asarray([0, 0, 0, 1, 1, 2])
     with pytest.raises(ValueError):
         compute_class_weight("balanced", classes=classes, y=y)
-    # Fix exception in error message formatting when missing label is a string
-    # https://github.com/scikit-learn/scikit-learn/issues/8312
-    with pytest.raises(ValueError, match="Class label label_not_present not present"):
-        compute_class_weight({"label_not_present": 1.0}, classes=classes, y=y)
     # Raise error when y has items not in classes
     classes = np.arange(2)
     with pytest.raises(ValueError):
         compute_class_weight("balanced", classes=classes, y=y)
     with pytest.raises(ValueError):
         compute_class_weight({0: 1.0, 1: 2.0}, classes=classes, y=y)
+    # Fix exception in error message formatting when missing label is a string
+    # https://github.com/scikit-learn/scikit-learn/issues/8312
+    classes = np.array(["label_not_present"])
+    y = np.array(["label_not_present"])
+    with pytest.raises(ValueError, match="Class label label_not_present not present"):
+        compute_class_weight({0: 1.0}, classes=classes, y=y)
 
 def test_compute_class_weight_dict():
     classes = np.arange(3)

--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -38,7 +38,7 @@ def test_compute_class_weight_not_present():
     # https://github.com/scikit-learn/scikit-learn/issues/8312
     classes = np.array(["label_not_present"])
     y = np.array(["label_not_present"])
-    with pytest.raises(ValueError, match="Class label label_not_present not present"):
+    with pytest.raises(ValueError, match="Class labels label_not_present not present"):
         compute_class_weight({0: 1.0}, classes=classes, y=y)
 
 def test_compute_class_weight_dict():
@@ -261,4 +261,3 @@ def test_compute_sample_weight_more_than_32():
     indices = np.arange(50)  # use subsampling
     weight = compute_sample_weight("balanced", y, indices=indices)
     assert_array_almost_equal(weight, np.ones(y.shape[0]))
-


### PR DESCRIPTION
Stop raising error when there is extra weights in the `class_weight` parameter in the forest.

Related issue: https://github.com/scikit-learn/scikit-learn/issues/22413